### PR TITLE
Use same values in vector, list, and set examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -204,7 +204,7 @@ Data Types
 | Map       | `{:foo "bar"}`
 | Vector    | `[1 2 "3"]`
 | List      | `(1 2 "3")`
-| Set       | `#{1 2 3}`
+| Set       | `#{1 2 "3"}`
 | Regex     | `#"^\w+$"`
 |===
 


### PR DESCRIPTION
By using the same values `1`, `2`, and `"3"`, it should be easier for people to see the difference between the syntax for these collections (while also demonstrating they can hold values of different types).
