### PR TITLE
Include full `core.cljs` source in tutorial

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -623,6 +623,8 @@ A simple main function that sets the content of a single DOM element:
 ._core.cljs_
 [source, clojure]
 ----
+(ns cljsworkshop.core)
+
 (defn set-html! [el content]
   (set! (.-innerHTML el) content))
 
@@ -631,6 +633,8 @@ A simple main function that sets the content of a single DOM element:
   (let [content "Hello World from ClojureScript"
         element (aget (js/document.getElementsByTagName "main") 0)]
     (set-html! element content)))
+
+(main)
 ----
 
 
@@ -729,6 +733,8 @@ Change the main function to something like this:
                      (swap! counter inc)
                      ;; Set new value in display element
                      (set! (.-innerHTML display) @counter)))))
+
+(main)
 ----
 
 


### PR DESCRIPTION
- Add a few more lines of context of the tutorial so readers see the
  `ns` macro, `main` function definition, and `(main)` function call.

(In response to https://github.com/niwibe/cljs-workshop-doc/commit/95279691a4d54efa65ec71f0d1d1776947dbfaf5#commitcomment-10802823).
