### PR TITLE
Remove `:closure-warnings` option from initial 'production-ready builds' section)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1676,7 +1676,6 @@ Replace your old build configuration in your *project.clj* with this:
    :compiler {:output-to "resources/public/js/app.js"
               :output-dir "resources/public/js/out-prod"
               :source-map "resources/public/js/app.js.map"
-              :closure-warnings {:externs-validation :off}
               :optimizations :advanced
               :cache-analysis false
               :asset-path "/static/js/out-prod"


### PR DESCRIPTION
`:closure-warnings` is introduced later when integrating with Moment.js

(In response to https://github.com/niwibe/cljs-workshop-doc/commit/27d78ecb093e4fd2b3bba97a3a6312a94af46245#commitcomment-10802856).
